### PR TITLE
Fixed the Uri in Zend\Request

### DIFF
--- a/src/Zend/Request.php
+++ b/src/Zend/Request.php
@@ -44,6 +44,7 @@ class Request extends BaseRequest
 
         $this->setMethod($method);
         $this->setRequestUri((string) $uri);
+        $this->setUri((string) $uri);
 
         $headerCollection = $this->getHeaders();
         foreach ($headers as $name => $values) {

--- a/test/Zend/RequestTest.php
+++ b/test/Zend/RequestTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Psr7Bridge\Zend;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Psr7Bridge\Zend\Request;
+
+class RequestTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $method  = 'GET';
+        $path    = '/foo';
+        $request = new Request($method, $path, [], [], [], [], [], []);
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertSame($method, $request->getMethod());
+        $this->assertSame($path, $request->getRequestUri());
+        $this->assertInstanceOf('Zend\Uri\Http', $request->getUri());
+        $this->assertSame($path, $request->getUri()->getPath());
+        $this->assertEmpty($request->getHeaders());
+        $this->assertEmpty($request->getCookie());
+        $this->assertEmpty($request->getQuery());
+        $this->assertEmpty($request->getPost());
+        $this->assertEmpty($request->getFiles());
+    }
+}


### PR DESCRIPTION
This PR fixes the Uri settings in Zend\Request. I also provided a unit test for Zend\Request.
The Uri settings was not specifed using setUri() and this can be a problem in different use cases, for instance in the Zf2 route matching [here](https://github.com/zendframework/zend-mvc/blob/master/src/Router/Http/TreeRouteStack.php#L260). 
