### PR TITLE
 Add the request/response conversion to/from zend-http

### DIFF
--- a/src/Psr7Response.php
+++ b/src/Psr7Response.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Psr7Bridge;
+
+use Psr\Http\Message\ResponseInterface;
+use Zend\Http\Response as ZendResponse;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Stream;
+
+final class Psr7Response
+{
+    /**
+     * Convert a PSR-7 response in a Zend\Http\Response
+     *
+     * @param  ResponseInterface $psr7Response
+     * @return ZendResponse
+     */
+    public static function toZend(ResponseInterface $psr7Response)
+    {
+        $response = sprintf(
+            "HTTP/%s %d %s\r\n%s\r\n%s",
+            $psr7Response->getProtocolVersion(),
+            $psr7Response->getStatusCode(),
+            $psr7Response->getReasonPhrase(),
+            self::getPsr7Headers($psr7Response),
+            (string) $psr7Response->getBody()
+        );
+        return ZendResponse::fromString($response);
+    }
+
+    private static function getPsr7Headers(ResponseInterface $psr7Response)
+    {
+        $headers = '';
+        foreach ($psr7Response->getHeaders() as $name => $value) {
+            $headers .= $name . ": " . implode(", ", $value) . "\r\n";
+        }
+        return $headers;
+    }
+
+    /**
+     * Convert a Zend\Http\Response in a PSR-7 response, using zend-diactoros
+     *
+     * @param  ZendResponse $zendResponse
+     * @return Response
+     */
+    public static function fromZend(ZendResponse $zendResponse)
+    {
+        $body = new Stream('php://temp', 'wb+');
+        $body->write($zendResponse->getBody());
+
+        return new Response(
+            $body,
+            $zendResponse->getStatusCode(),
+            $zendResponse->getHeaders()->toArray()
+        );
+    }
+
+    /**
+     * Do not allow instantiation.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Psr7Response.php
+++ b/src/Psr7Response.php
@@ -29,13 +29,19 @@ final class Psr7Response
             $psr7Response->getProtocolVersion(),
             $psr7Response->getStatusCode(),
             $psr7Response->getReasonPhrase(),
-            self::getPsr7Headers($psr7Response),
+            self::psr7HeadersToString($psr7Response),
             (string) $psr7Response->getBody()
         );
         return ZendResponse::fromString($response);
     }
 
-    private static function getPsr7Headers(ResponseInterface $psr7Response)
+    /**
+     * Convert the PSR-7 headers to string
+     *
+     * @param ResponseInterface $psr7Response
+     * @return string
+     */
+    private static function psr7HeadersToString(ResponseInterface $psr7Response)
     {
         $headers = '';
         foreach ($psr7Response->getHeaders() as $name => $value) {

--- a/test/Psr7ResponseTest.php
+++ b/test/Psr7ResponseTest.php
@@ -24,11 +24,11 @@ class Psr7ResponseTest extends TestCase
             [ '', 204, [] ],
             [ 'Test!', 200, [
                 'Content-Type'   => [ 'text/html; charset=utf-8' ],
-                'Content-Length' => [ 5 ]
+                'Content-Length' => [ '5' ]
             ]],
             [ 'Test!', 202, [
                 'Content-Type'   => [ 'text/html; level=1', 'text/html' ],
-                'Content-Length' => [ 5 ]
+                'Content-Length' => [ '5' ]
             ]],
         ];
     }
@@ -48,19 +48,13 @@ class Psr7ResponseTest extends TestCase
         $this->assertInstanceOf('Zend\Http\Response', $zendResponse);
         $this->assertEquals($body, (string) $zendResponse->getBody());
         $this->assertEquals($status, $zendResponse->getStatusCode());
-        $this->assertEquals($headers, $this->zendToPsr7Headers($zendResponse->getHeaders()));
-    }
 
-    /**
-     * Transform a Zend headers into Psr7 headers
-     */
-    protected function zendToPsr7Headers($headers)
-    {
-        $zendHeaders = $headers->toArray();
-        foreach ($zendHeaders as $type => $value) {
-            $zendHeaders[$type] = explode(', ', $value);
+        $zendHeaders = $zendResponse->getHeaders()->toArray();
+        foreach ($headers as $type => $values) {
+            foreach ($values as $value) {
+                $this->assertContains($value, $zendHeaders[$type]);
+            }
         }
-        return $zendHeaders;
     }
 
     public function getResponseString()
@@ -69,6 +63,7 @@ class Psr7ResponseTest extends TestCase
             [ "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\r\nTest!" ],
             [ "HTTP/1.1 204 OK\r\n\r\n" ],
             [ "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\nTest!" ],
+            [ "HTTP/1.1 200 OK\r\nContent-Type: text/html, text/xml\r\nContent-Length: 5\r\n\r\nTest!" ],
         ];
     }
 
@@ -83,6 +78,12 @@ class Psr7ResponseTest extends TestCase
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $psr7Response);
         $this->assertEquals((string) $psr7Response->getBody(), $zendResponse->getBody());
         $this->assertEquals($psr7Response->getStatusCode(), $zendResponse->getStatusCode());
-        $this->assertEquals($psr7Response->getHeaders(), $this->zendToPsr7Headers($zendResponse->getHeaders()));
+
+        $zendHeaders = $zendResponse->getHeaders()->toArray();
+        foreach ($psr7Response->getHeaders() as $type => $values) {
+            foreach ($values as $value) {
+                $this->assertContains($value, $zendHeaders[$type]);
+            }
+        }
     }
 }

--- a/test/Psr7ResponseTest.php
+++ b/test/Psr7ResponseTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Psr7Bridge;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Stream;
+use Zend\Psr7Bridge\Psr7Response;
+use Zend\Http\Response as ZendResponse;
+
+class Psr7ResponseTest extends TestCase
+{
+    public function getResponseData()
+    {
+        return [
+            [ 'Test!', 200, [ 'Content-Type' => [ 'text/html' ] ] ],
+            [ '', 204, [] ],
+            [ 'Test!', 200, [
+                'Content-Type'   => [ 'text/html; charset=utf-8' ],
+                'Content-Length' => [ 5 ]
+            ]],
+            [ 'Test!', 202, [
+                'Content-Type'   => [ 'text/html; level=1', 'text/html' ],
+                'Content-Length' => [ 5 ]
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider getResponseData
+     */
+    public function testResponseToZend($body, $status, $headers)
+    {
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write($body);
+
+        $psr7Response = new Response($stream, $status, $headers);
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $psr7Response);
+
+        $zendResponse = Psr7Response::toZend($psr7Response);
+        $this->assertInstanceOf('Zend\Http\Response', $zendResponse);
+        $this->assertEquals($body, (string) $zendResponse->getBody());
+        $this->assertEquals($status, $zendResponse->getStatusCode());
+        $this->assertEquals($headers, $this->zendToPsr7Headers($zendResponse->getHeaders()));
+    }
+
+    /**
+     * Transform a Zend headers into Psr7 headers
+     */
+    protected function zendToPsr7Headers($headers)
+    {
+        $zendHeaders = $headers->toArray();
+        foreach ($zendHeaders as $type => $value) {
+            $zendHeaders[$type] = split(', ', $value);
+        }
+        return $zendHeaders;
+    }
+
+    public function getResponseString()
+    {
+        return [
+            [ "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\r\nTest!" ],
+            [ "HTTP/1.1 204 OK\r\n\r\n" ],
+            [ "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\nTest!" ],
+        ];
+    }
+
+    /**
+     * @dataProvider getResponseString
+     */
+    public function testResponseFromZend($response)
+    {
+        $zendResponse = ZendResponse::fromString($response);
+        $this->assertInstanceOf('Zend\Http\Response', $zendResponse);
+        $psr7Response = Psr7Response::fromZend($zendResponse);
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $psr7Response);
+        $this->assertEquals((string) $psr7Response->getBody(), $zendResponse->getBody());
+        $this->assertEquals($psr7Response->getStatusCode(), $zendResponse->getStatusCode());
+        $this->assertEquals($psr7Response->getHeaders(), $this->zendToPsr7Headers($zendResponse->getHeaders()));
+    }
+}

--- a/test/Psr7ResponseTest.php
+++ b/test/Psr7ResponseTest.php
@@ -58,7 +58,7 @@ class Psr7ResponseTest extends TestCase
     {
         $zendHeaders = $headers->toArray();
         foreach ($zendHeaders as $type => $value) {
-            $zendHeaders[$type] = split(', ', $value);
+            $zendHeaders[$type] = explode(', ', $value);
         }
         return $zendHeaders;
     }


### PR DESCRIPTION
This PR adds the request/response conversion to/from [zend-http](https://github.com/zendframework/zend-http).

To do:
- [x] PSR-7 response to Zend\Http\Response
- [x] Zend\Http\Response to PSR-7 response
- [x] Zend\Http\Request to PSR-7 request

The PSR-7 request and response are built using [zend-diactoros](https://github.com/zendframework/zend-diactoros).
