### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - secure: "QsS9xhQuW/8b3kiYNf1mAN2DpGkyqFGqcUZzv4wO+IMhq7NeE9HST7y5H0ByecJb822DBh6IZMEH3a75J0ekECFlYYdXj54ZzXghEAqL+R3uwmlxNGvmj1Q8N/VS5xt0N6qusN8a91tvXOsprKwzFY2v+/aS+gnaNIKha69Z9nlqcQnrAaeldWgBJcc//Y/sf0k0bzpqFScAwkgEVVk6PI1yuwXhnNiJa0e7YFbVJrk1uMQVNuKIUaQfQEMX4pI7RfhtD6/oOrwxt35ep35NNfEAG8UhAmv0vSZ9xEcepwu37cnS06Jn2g7PAQ0QYwrxv01OGrtprrD98SQaXJV9HcBDmbjh4L3+rVRR5j9moIob4jj20K3d7AmNzt5Ffe5v0TBk43pw7Ub0tFbwpDlcHKDqd97tPanUJso/TIEIprYap/5rY5HwDwvYn3xelKYWtvuJg3Qc9joJkRp2cuWXEjnKjlmeFW0YoX1Qv9fSuuWjJ9aMFqteZFQLxe64byQs0j64QiHSPMSGOT569JgxsFqcrfWkHKmvyiYQJknMWKN3DxdSlKk089jyA28QcSC8unEV25bhpCMEBFF1GOzX3IrcH12qf3EcP37xJiEVDkOAL0///+oxRQanqMPxynfUAmiY9+58GACeoaxqPM+yvpUBIDwnM3p2qG0VN1Hcn9I="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
