### PR TITLE
Fix #27 issue, baseUrl from PSR7 server request

### DIFF
--- a/src/Zend/Request.php
+++ b/src/Zend/Request.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Psr7Bridge\Zend;
 
+use Psr\Http\Message\UriInterface;
 use Zend\Http\Header\Cookie;
 use Zend\Http\PhpEnvironment\Request as BaseRequest;
 use Zend\Stdlib\Parameters;
@@ -43,7 +44,8 @@ class Request extends BaseRequest
         $this->setAllowCustomMethods(true);
 
         $this->setMethod($method);
-        $this->setRequestUri((string) $uri);
+        // Remove the "http(s)://hostname" part from the URI
+        $this->setRequestUri(preg_replace('#^[^/:]+://[^/]+#', '', (string) $uri));
         $this->setUri((string) $uri);
 
         $headerCollection = $this->getHeaders();


### PR DESCRIPTION
This PR fixes #27. It also fixes a couple of wrong behaviours in the previous tests using `getRequestUri()`. The `setRequestUri` for `Zend\Psr7Bridge\Zend\Request` needs to remove the `http(s)://hostname` from a URI. See the `Zend\Http\PhpEnvironment\Request` implementation [here](https://github.com/zendframework/zend-http/blob/master/src/PhpEnvironment/Request.php#L464).