### PR TITLE
Fixes converting psr request with memory stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,29 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Nothing.
 
-## 1.0.1 - TBD
+## 1.0.2 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.0.1 - 2017-12-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#35](https://github.com/zendframework/zend-psr7bridge/pull/35) fixes the
+  Response from a PSR-7 Stream object with php://memory stream
 
 ## 1.0.1 - 2017-12-18
 

--- a/src/Psr7Response.php
+++ b/src/Psr7Response.php
@@ -19,6 +19,7 @@ use Zend\Http\Response as ZendResponse;
 final class Psr7Response
 {
     const URI_TEMP = 'php://temp';
+    const URI_MEMORY = 'php://memory';
 
     /**
      * Convert a PSR-7 response in a Zend\Http\Response
@@ -31,7 +32,7 @@ final class Psr7Response
     {
         $uri = $psr7Response->getBody()->getMetadata('uri');
 
-        if ($uri === static::URI_TEMP) {
+        if ($uri === static::URI_TEMP || $uri === static::URI_MEMORY) {
             $response = sprintf(
                 "HTTP/%s %d %s\r\n%s\r\n%s",
                 $psr7Response->getProtocolVersion(),

--- a/test/Psr7ResponseTest.php
+++ b/test/Psr7ResponseTest.php
@@ -59,6 +59,30 @@ class Psr7ResponseTest extends TestCase
     /**
      * @dataProvider getResponseData
      */
+    public function testResponseToZendWithMemoryStream($body, $status, $headers)
+    {
+        $stream = new Stream('php://memory', 'wb+');
+        $stream->write($body);
+
+        $psr7Response = new Response($stream, $status, $headers);
+        $this->assertInstanceOf(ResponseInterface::class, $psr7Response);
+
+        $zendResponse = Psr7Response::toZend($psr7Response);
+        $this->assertInstanceOf(ZendResponse::class, $zendResponse);
+        $this->assertEquals($body, (string)$zendResponse->getBody());
+        $this->assertEquals($status, $zendResponse->getStatusCode());
+
+        $zendHeaders = $zendResponse->getHeaders()->toArray();
+        foreach ($headers as $type => $values) {
+            foreach ($values as $value) {
+                $this->assertContains($value, $zendHeaders[$type]);
+            }
+        }
+    }
+
+    /**
+     * @dataProvider getResponseData
+     */
     public function testResponseToZendFromRealStream($body, $status, $headers)
     {
         $stream = new Stream(tempnam(sys_get_temp_dir(), 'Test'), 'wb+');


### PR DESCRIPTION
Fixes body content discarded for `php://memory` stream, bug introduced in #26 while adding support for file based streams.

Proper fix will likely need whitelisting of file based streams instead of the used approach.