### PR TITLE
add zend-diactoros ^2.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-diactoros": "^1.7",
+        "zendframework/zend-diactoros": "^1.7|^2.0",
         "zendframework/zend-http": "^2.7"
     },
     "require-dev": {


### PR DESCRIPTION
to keep it working when zend-diactoros upgraded to v2 and use it as well.